### PR TITLE
Update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,21 @@ A set of function to autocomplete commands and options of the heroku gem.
 
     $ heroku cr[TAB] # => create
 
-    $ heroku o[TAB] # => open
+    $ heroku i[TAB] # => info
 
-    $ heroku open --[TAB]
-    --addons   --app      --remote   --stack    --timeout
+    $ heroku addons --[TAB]
+    --all       --app       --resource
 
-    $ heroku db:[TAB]
-    db:pull   db:push   db:reset
-
-    $ heroku db:pull --[TAB]
-    --chunksize            --disable-compression  --force                --resume-filename
-    --debug                --filter               --indexes-last         --tables
+    $ heroku addons:[TAB]
+    add        attach     create     destroy    detach     docsdowngrade
+    list       open       plans      remove     services   upgrade
 
     $ heroku rake[TAB] # => it will show all your rake tasks
 
     $ heroku rake db:mi[TAB] # => db:migrate
 
-	$ heroku info --app my[TAB] # => myapp
-	
-
-## Known bugs
-
-The heroku application completion is not working at 100%, it completes the app name but the line behaves in a weird way.
+    $ heroku info --app my[TAB] # => myapp
 
 ## ToDo
 
-* Fix the completion of heroku app names
 * Make it dynamic (right know all the commands an options are hard coded)

--- a/generate_heroku_aliases.sh
+++ b/generate_heroku_aliases.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -n "$1" ]; then
+  echo "Usage: $0"
+  echo
+  echo "Outputs the list of all heroku aliases, as a bash associative array"
+  exit
+fi
+
+echo "declare -A __heroku_aliases=("
+
+source_path=$(locate /lib/heroku/command | head -1)
+grep -Rh alias_command ${source_path} | sed -n "s/^ \+alias_command \+[\'\"]\(.*\)[\'\"], *[\'\"]\(.*\)[\'\"]/  [\"\1\"]=\"\2\"/p"
+
+echo ")"

--- a/generate_heroku_commands_and_options.sh
+++ b/generate_heroku_commands_and_options.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -n "$1" ]; then
+  echo "Usage: $0"
+  echo
+  echo "Outputs the list of all heroku commands and subcommands, with their options, as a bash associative array"
+  exit
+fi
+
+commands=$(heroku help | grep -v '^[A-Z]' | sed -n 's/#.*//p' | tr '\n' ' ')
+
+echo "declare -A __heroku_commands_and_options=("
+
+for cmd in $commands; do
+  options="$(heroku help $cmd | grep -o '^ \+--[^ ]\+')"
+  echo -n "  [\"$cmd\"]=\""
+  for opt in $options; do
+    echo -n "$opt "
+  done
+  echo "\""
+
+  subcommands=$(heroku help $cmd | grep "$cmd:" | awk '{{print $1}}')
+  for subcmd in $subcommands; do
+    suboptions="$(heroku help $subcmd | grep '^ \+\(-., \)\?--[^ ]\+' | grep -o '\--[^ ]\+')"
+    echo -n "  [\"$subcmd\"]=\""
+    for subopt in $suboptions; do
+      echo -n "$subopt "
+    done
+    echo "\""
+  done
+done
+
+echo ")"

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -1,49 +1,27 @@
 __heroku_complete_base()
 {
   local current_word previous_word
-  local general_commands app_commands all_commands
-  local app_options db_options
 
-  COMPREPLY=()
-
-  current_word="${COMP_WORDS[COMP_CWORD]}"
-  previous_word="${COMP_WORDS[COMP_CWORD-1]}"
-
-  general_commands="help version list create keys keys:add keys:remove keys:clear"
-  app_commands="info open rename dynos workers sharing:add sharing:remove sharing:transfer domains:add domains:remove domains:clear ssl:add ssl:remove rake console restart logs logs:cron maintenance:on maintenance:off config config:add config:remove config:clear stack stack:migrate bundles bundles:capture bundles:download bundles:download bundles:animate bundles:destroy addons addons:info addons:add addons:remove addons:clear destroy plugins plugins:install plugins:uninstall"
-  db_commands="db:pull db:push db:reset"
-  all_commands="${general_commands} ${app_commands} ${db_commands}"
-
-  app_options="--app --remote --stack --timeout --addons"
-  db_options="--force --chunksize --filter --tables --disable-compression --resume-filename --indexes-last --debug"
+  _get_comp_words_by_ref -n ':' -c current_word -p previous_word
 
   case "${previous_word}" in
     --app|-a)
-      COMPREPLY=($(compgen -W "$(__heroku_apps)" -- ${current_word}))
+      COMPREPLY=($(compgen -W '$(__heroku_apps)' -- ${current_word}))
       return 0
       ;;
     rake)
-      COMPREPLY=($(compgen -W "$(__rake_tasks)" -- ${current_word}))
+      COMPREPLY=($(compgen -W '$(__rake_tasks)' -- ${current_word}))
       return 0
       ;;
   esac
 
-  if [[ $app_commands == *$previous_word* ]]; then
-    COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
+  if [[ ${current_word} == -* ]]; then
+    COMPREPLY=($(compgen -W '${__heroku_commands_and_options["${previous_word}"]}' -- ${current_word}))
     return 0
   fi
 
-  if [[ $db_commands == *$previous_word* ]]; then
-    COMPREPLY=($(compgen -W "${db_options}" -- ${current_word}))
-    return 0
-  fi
-
-  if [[ ${current_word} == -* ]] ; then
-    COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
-    return 0
-    fi
-
-  COMPREPLY=($(compgen -W "${all_commands}" -- ${current_word}))
+  COMPREPLY=($(compgen -W '${!__heroku_commands_and_options[@]}' -- ${current_word}))
+  __ltrim_colon_completions "$current_word"
 }
 
 __heroku_apps()
@@ -57,3 +35,148 @@ __rake_tasks()
 }
 
 complete -F __heroku_complete_base heroku
+
+declare -A __heroku_commands_and_options=(
+  ["addons"]="--all --app --resource "
+  ["addons:attach"]="--as --confirm "
+  ["addons:create"]="--name --as --confirm "
+  ["addons:destroy"]="--force "
+  ["addons:detach"]=""
+  ["addons:docs"]=""
+  ["addons:downgrade"]=""
+  ["addons:open"]=""
+  ["addons:plans"]=""
+  ["addons:services"]=""
+  ["addons:upgrade"]=""
+  ["apps"]=""
+  ["apps:create"]="--addons --buildpack --no-remote --remote --stack --region --locked --ssh-git "
+  ["apps:destroy"]=""
+  ["apps:info"]="--shell "
+  ["apps:join"]="--app "
+  ["apps:leave"]="--app "
+  ["apps:lock"]=""
+  ["apps:open"]=""
+  ["apps:rename"]="--ssh-git "
+  ["apps:unlock"]=""
+  ["auth"]=""
+  ["auth:login"]=""
+  ["auth:logout"]=""
+  ["auth:password"]=""
+  ["auth:token"]=""
+  ["auth:user"]=""
+  ["auth:whoami"]=""
+  ["config"]=""
+  ["config:get"]="--shell "
+  ["config:set"]=""
+  ["config:unset"]=""
+  ["domains"]=""
+  ["domains:add"]=""
+  ["domains:clear"]=""
+  ["domains:remove"]=""
+  ["logs"]=""
+  ["ps"]=""
+  ["ps:resize"]=""
+  ["ps:restart"]=""
+  ["ps:scale"]=""
+  ["ps:stop"]=""
+  ["ps:type"]=""
+  ["releases"]=""
+  ["releases:info"]="--shell "
+  ["releases:rollback"]=""
+  ["run"]="--exit-code "
+  ["run:detached"]="--size --tail "
+  ["run:rake"]=""
+  ["sharing"]=""
+  ["sharing:add"]=""
+  ["sharing:remove"]=""
+  ["sharing:transfer"]="--locked "
+  ["accounts"]=""
+  ["accounts:add"]="--auto "
+  ["accounts:default"]=""
+  ["accounts:remove"]=""
+  ["accounts:set"]=""
+  ["buildpacks"]=""
+  ["buildpacks:add"]="--index "
+  ["buildpacks:clear"]=""
+  ["buildpacks:remove"]="--index "
+  ["buildpacks:set"]="--index "
+  ["certs"]=""
+  ["certs:add"]="--bypass "
+  ["certs:chain"]=""
+  ["certs:generate"]="--city --selfsigned --keysize --owner --country --area --city --subject --now "
+  ["certs:info"]="--endpoint "
+  ["certs:key"]=""
+  ["certs:remove"]="--endpoint "
+  ["certs:rollback"]="--endpoint "
+  ["certs:update"]="--bypass --endpoint "
+  ["drains"]=""
+  ["drains:add"]=""
+  ["drains:remove"]=""
+  ["features"]=""
+  ["features:disable"]=""
+  ["features:enable"]=""
+  ["features:info"]=""
+  ["fork"]="--region --skip-pg "
+  ["git"]=""
+  ["git:clone"]="--app --remote --ssh-git "
+  ["git:remote"]="--app --remote --ssh-git "
+  ["help"]="--addons "
+  ["keys"]=""
+  ["keys:add"]=""
+  ["keys:clear"]=""
+  ["keys:remove"]=""
+  ["labs"]=""
+  ["labs:disable"]=""
+  ["labs:enable"]=""
+  ["labs:info"]=""
+  ["local"]=""
+  ["maintenance"]=""
+  ["maintenance:off"]=""
+  ["maintenance:on"]=""
+  ["members"]=""
+  ["members:add"]="--role "
+  ["members:remove"]=""
+  ["members:set"]="--role "
+  ["orgs"]=""
+  ["orgs:open"]=""
+  ["pg"]=""
+  ["pg:backups"]="--quiet --at "
+  ["pg:copy"]=""
+  ["pg:credentials"]="--reset "
+  ["pg:diagnose"]=""
+  ["pg:info"]="--extended "
+  ["pg:kill"]=""
+  ["pg:killall"]=""
+  ["pg:maintenance"]="--force "
+  ["pg:promote"]=""
+  ["pg:ps"]=""
+  ["pg:psql"]="--command "
+  ["pg:pull"]=""
+  ["pg:push"]=""
+  ["pg:reset"]=""
+  ["pg:unfollow"]=""
+  ["pg:upgrade"]=""
+  ["pg:wait"]="--wait-interval "
+  ["pgbackups"]=""
+  ["pgbackups:capture"]="--expire "
+  ["pgbackups:destroy"]=""
+  ["pgbackups:restore"]=""
+  ["pgbackups:transfer"]=""
+  ["pgbackups:url"]=""
+  ["plugins"]=""
+  ["plugins:install"]=""
+  ["plugins:link"]=""
+  ["plugins:uninstall"]=""
+  ["plugins:update"]=""
+  ["redis"]=""
+  ["regions"]=""
+  ["stack"]=""
+  ["stack:set"]=""
+  ["status"]=""
+  ["twofactor"]=""
+  ["twofactor:disable"]=""
+  ["twofactor:generate-recovery-codes"]=""
+  ["update"]=""
+  ["update:beta"]=""
+  ["version"]=""
+)

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -2,6 +2,10 @@ __heroku_complete_base()
 {
   local current_word previous_word
 
+  for alias in "${!__heroku_aliases[@]}"; do
+    __heroku_commands_and_options[${alias}]=__heroku_commands_and_options[__heroku_aliases[${alias}]]
+  done
+
   _get_comp_words_by_ref -n ':' -c current_word -p previous_word
 
   case "${previous_word}" in
@@ -180,4 +184,45 @@ declare -A __heroku_commands_and_options=(
   ["update"]=""
   ["update:beta"]=""
   ["version"]=""
+)
+
+declare -A __heroku_aliases=(
+  ["-h"]="help"
+  ["--help"]="help"
+  ["config:add"]="config:set"
+  ["config:remove"]="config:unset"
+  ["features:list"]="features"
+  ["2fa"]="twofactor"
+  ["2fa:disable"]="twofactor:disable"
+  ["2fa:generate-recovery-codes"]="twofactor:generate_recovery_codes"
+  ["dynos"]="ps:dynos"
+  ["workers"]="ps:workers"
+  ["restart"]="ps:restart"
+  ["scale"]="ps:scale"
+  ["stop"]="ps:stop"
+  ["resize"]="ps:type"
+  ["stack:migrate"]="stack:set"
+  ["rake"]="run:rake"
+  ["console"]="run:console"
+  ["login"]="auth:login"
+  ["logout"]="auth:logout"
+  ["list"]="apps"
+  ["info"]="apps:info"
+  ["create"]="apps:create"
+  ["rename"]="apps:rename"
+  ["open"]="apps:open"
+  ["destroy"]="apps:destroy"
+  ["apps:delete"]="apps:destroy"
+  ["join"]="apps:join"
+  ["leave"]="apps:leave"
+  ["lock"]="apps:lock"
+  ["unlock"]="apps:unlock"
+  ["upgrade"]="apps:upgrade"
+  ["downgrade"]="apps:downgrade"
+  ["rollback"]="releases:rollback"
+  ["labs:list"]="labs"
+  ["addons:list"]="addons:services"
+  ["addons:add"]="addons:create"
+  ["addons:remove"]="addons:destroy"
+  ["clone"]="git:clone"
 )

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -11,6 +11,7 @@ __heroku_complete_base()
       ;;
     rake)
       COMPREPLY=($(compgen -W '$(__rake_tasks)' -- ${current_word}))
+      __ltrim_colon_completions "$current_word"
       return 0
       ;;
   esac
@@ -26,12 +27,12 @@ __heroku_complete_base()
 
 __heroku_apps()
 {
-  echo `heroku list | awk '{{print $1}}' | grep -v '^=*$' | tr '\n' ' '`
+  echo $(heroku list | awk '{{print $1}}' | grep -v '^=*$' | tr '\n' ' ')
 }
 
 __rake_tasks()
 {
-  echo `rake -s -T 2>/dev/null | awk '{{print $2}}'`
+  echo $(rake -sT 2>/dev/null | awk '{{print $2}}')
 }
 
 complete -F __heroku_complete_base heroku

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -18,7 +18,7 @@ __heroku_complete_base()
   db_options="--force --chunksize --filter --tables --disable-compression --resume-filename --indexes-last --debug"
 
   case "${previous_word}" in
-    --app)
+    --app|-a)
       COMPREPLY=($(compgen -W "$(__heroku_apps)" -- ${current_word}))
       return 0
       ;;

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -48,7 +48,7 @@ __heroku_complete_base()
 
 __heroku_apps()
 {
-  echo `heroku list | awk '{{print $1}}' | tr '\n' ' '`
+  echo `heroku list | awk '{{print $1}}' | grep -v '^=*$' | tr '\n' ' '`
 }
 
 __rake_tasks()

--- a/heroku_bash_completion.sh
+++ b/heroku_bash_completion.sh
@@ -1,59 +1,59 @@
 __heroku_complete_base()
 {
-    local current_word previous_word
-	local general_commands app_commands all_commands 
-	local app_options db_options
-	
-    COMPREPLY=()
+  local current_word previous_word
+  local general_commands app_commands all_commands
+  local app_options db_options
 
-    current_word="${COMP_WORDS[COMP_CWORD]}"
-    previous_word="${COMP_WORDS[COMP_CWORD-1]}"
-	
-	general_commands="help version list create keys keys:add keys:remove keys:clear"
-	app_commands="info open rename dynos workers sharing:add sharing:remove sharing:transfer domains:add domains:remove domains:clear ssl:add ssl:remove rake console restart logs logs:cron maintenance:on maintenance:off config config:add config:remove config:clear stack stack:migrate bundles bundles:capture bundles:download bundles:download bundles:animate bundles:destroy addons addons:info addons:add addons:remove addons:clear destroy plugins plugins:install plugins:uninstall"
-	db_commands="db:pull db:push db:reset"
-	all_commands="${general_commands} ${app_commands} ${db_commands}"
-	
-	app_options="--app --remote --stack --timeout --addons"
-	db_options="--force --chunksize --filter --tables --disable-compression --resume-filename --indexes-last --debug"
-	
-	case "${previous_word}" in
-		--app)
-			COMPREPLY=($(compgen -W "$(__heroku_apps)" -- ${current_word}))
-			return 0
-			;;
-		rake)
-			COMPREPLY=($(compgen -W "$(__rake_tasks)" -- ${current_word}))
-			return 0
-			;;
-	esac
-	
-	if [[ $app_commands == *$previous_word* ]]; then
-		COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
-		return 0
-	fi
+  COMPREPLY=()
 
-	if [[ $db_commands == *$previous_word* ]]; then
-		COMPREPLY=($(compgen -W "${db_options}" -- ${current_word}))
-		return 0
-	fi
-	
-	if [[ ${current_word} == -* ]] ; then
-		COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
-		return 0
+  current_word="${COMP_WORDS[COMP_CWORD]}"
+  previous_word="${COMP_WORDS[COMP_CWORD-1]}"
+
+  general_commands="help version list create keys keys:add keys:remove keys:clear"
+  app_commands="info open rename dynos workers sharing:add sharing:remove sharing:transfer domains:add domains:remove domains:clear ssl:add ssl:remove rake console restart logs logs:cron maintenance:on maintenance:off config config:add config:remove config:clear stack stack:migrate bundles bundles:capture bundles:download bundles:download bundles:animate bundles:destroy addons addons:info addons:add addons:remove addons:clear destroy plugins plugins:install plugins:uninstall"
+  db_commands="db:pull db:push db:reset"
+  all_commands="${general_commands} ${app_commands} ${db_commands}"
+
+  app_options="--app --remote --stack --timeout --addons"
+  db_options="--force --chunksize --filter --tables --disable-compression --resume-filename --indexes-last --debug"
+
+  case "${previous_word}" in
+    --app)
+      COMPREPLY=($(compgen -W "$(__heroku_apps)" -- ${current_word}))
+      return 0
+      ;;
+    rake)
+      COMPREPLY=($(compgen -W "$(__rake_tasks)" -- ${current_word}))
+      return 0
+      ;;
+  esac
+
+  if [[ $app_commands == *$previous_word* ]]; then
+    COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
+    return 0
+  fi
+
+  if [[ $db_commands == *$previous_word* ]]; then
+    COMPREPLY=($(compgen -W "${db_options}" -- ${current_word}))
+    return 0
+  fi
+
+  if [[ ${current_word} == -* ]] ; then
+    COMPREPLY=($(compgen -W "${app_options}" -- ${current_word}))
+    return 0
     fi
-	
-	COMPREPLY=($(compgen -W "${all_commands}" -- ${current_word}))
+
+  COMPREPLY=($(compgen -W "${all_commands}" -- ${current_word}))
 }
 
 __heroku_apps()
 {
-	echo `heroku list | awk '{{print $1}}' | tr '\n' ' '`
+  echo `heroku list | awk '{{print $1}}' | tr '\n' ' '`
 }
 
 __rake_tasks()
 {
-	echo `rake -s -T 2>/dev/null | awk '{{print $2}}'`
+  echo `rake -s -T 2>/dev/null | awk '{{print $2}}'`
 }
 
 complete -F __heroku_complete_base heroku


### PR DESCRIPTION
This PR:
- updates heroku commands & options
- supports aliases
- provides 2 scripts to generate commands and aliases arrays from heroku doc and source
- supports colons in completion
- adds support for `-a`
- fixes completion of applications proposing `===` as an application name
